### PR TITLE
Bugfix: Pilsbaas is now correctly calculated over a zuipday

### DIFF
--- a/app/src/main/java/com/tobo/huiset/achievements/Achievements.kt
+++ b/app/src/main/java/com/tobo/huiset/achievements/Achievements.kt
@@ -50,7 +50,7 @@ class PilsBaas : BaseAchievement() {
     override fun checkIfAchieved(person: Person, helpData: AchievementUpdateHelpData): Long? {
 
         val maxBeerOnADay = helpData.beerTurfTransactionsByPerson
-            .groupBy {it.toboTime.toboDay}
+            .groupBy {it.toboTime.getZuipDay()}
 
         // a map entry for each day. Find one that meets our needs
         val goodDayEntry = maxBeerOnADay.entries.find { it.value.amountOfProducts() >= 10}

--- a/app/src/main/java/com/tobo/huiset/achievements/BaseAchievement.kt
+++ b/app/src/main/java/com/tobo/huiset/achievements/BaseAchievement.kt
@@ -22,9 +22,7 @@ abstract class BaseAchievement {
     fun update(person: Person, helpData: AchievementUpdateHelpData): AchievementCompletion?{
         if(wasAchieved(person)) return null
 
-        val completionTimeStamp = checkIfAchieved(person,helpData)
-
-        if(completionTimeStamp == null)return null
+        val completionTimeStamp = checkIfAchieved(person,helpData) ?: return null
 
         return person.getDb().createAndSaveAchievementCompletion(this, completionTimeStamp,person)
 


### PR DESCRIPTION
it is no longer calculated over a normal day, but instead over a ToboTime.getZuipday


closes #199 