### PR TITLE
Bugfix: hideKeyboard hold finger crash

### DIFF
--- a/app/src/main/java/com/tobo/huiset/gui/activities/EditProductActivity.kt
+++ b/app/src/main/java/com/tobo/huiset/gui/activities/EditProductActivity.kt
@@ -233,7 +233,7 @@ class EditProductActivity : HuisEtActivity() {
      */
     fun hideKeyboard(view: View) {
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
 
 }

--- a/app/src/main/java/com/tobo/huiset/gui/activities/EditProfileActivity.kt
+++ b/app/src/main/java/com/tobo/huiset/gui/activities/EditProfileActivity.kt
@@ -172,7 +172,7 @@ class EditProfileActivity : HuisEtActivity() {
      */
     fun hideKeyboard(view: View) {
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(currentFocus!!.windowToken, 0)
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
 
 }


### PR DESCRIPTION
Application no longer crashes when holding your finger in EditProfile or EditProduct.

closes #161 