### PR TITLE
Change "Geschiedenis" to "Verleden"

### DIFF
--- a/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -28,7 +28,7 @@
         android:icon="@drawable/baseline_history_white_24"
         android:id="@+id/action_history"
         android:enabled="true"
-        android:title="Geschiedenis"
+        android:title="Verleden"
         app:showAsAction="always" />
 
     <item


### PR DESCRIPTION
so it doesn't get abbreviated when the tab is active.

closes #219 